### PR TITLE
Delegator

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift(File.expand_path(File.join('..', 'lib'), __FILE__))
 
 namespace :update do
-	task :production do
+	task :to_production do
 		require 'site/logger'
 
 		Site::Logger.level = ::Logger::DEBUG

--- a/lib/site/logger.rb
+++ b/lib/site/logger.rb
@@ -1,8 +1,13 @@
 require 'logger'
 
+require 'site/multi_delegator'
+
 module Site
 
-	Logger = Logger.new(STDOUT)
+	LOG_FILE = File.open(File.expand_path(File.join('..', '..', '..', 'log', "site-#{File.basename $0}-#{Process.pid}.log"), __FILE__), 'a')
+
+	# This is the logger that we use in our app.
+	Logger = Logger.new MultiDelegator.delegate(:write, :close).to(STDOUT, LOG_FILE)
 	self::Logger.level = ::Logger::DEBUG
 
 end

--- a/lib/site/multi_delegator.rb
+++ b/lib/site/multi_delegator.rb
@@ -1,0 +1,29 @@
+module Site
+
+	# This class is primarily responsible for dealing
+	# with distributing calls between `Object`s; this enables us to
+	# make calls between each of the `Object`s by calling them on
+	# the `MultiDelegator` object instead.
+	class MultiDelegator
+		def initialize(*targets)
+			@targets = targets
+		end
+
+		def self.delegate(*methods)
+			methods.each do |_method|
+				define_method(_method) do |*arguments|
+					@targets.map do |_target|
+						_target.send(_method, *arguments)
+					end
+				end
+			end
+
+			self
+		end
+
+		class << self
+			alias to new
+		end
+	end
+
+end

--- a/script/production-update
+++ b/script/production-update
@@ -4,6 +4,4 @@ dirname=$(dirname $0)
 
 cd $dirname/..
 
-echo "[script/production-update] Running rake update-production"
-
-rake update:production
+rake update:to_production


### PR DESCRIPTION
This PR introduces a new `MultiDelegator` class which can delegate specified methods to targets.

Usage of the `MultiDelegator` class can be found in the `lib/site/logger.rb` file; we use this as a form of the common Unix utility `Tee` to share output between multiple IO objects.  `Logger` only requires that `:write` and `:close` are methods on responders, so the `MultiDelegator` automatically generates those methods to map over each of its targets and call `:write` or `:close` on each respectively.

Quite clever! ✨ 
