### PR TITLE
Add Android Theme Color

### DIFF
--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -14,6 +14,8 @@
 
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="version" content="<%= @git_describe %>" />
+
+		<!-- Android theme-color meta attribute for stylizing Chrome bar -->
 		<meta name="theme-color" content="#08519c" />
 
 		<meta name="author" content="Kristofer Rye" />

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -14,6 +14,7 @@
 
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="version" content="<%= @git_describe %>" />
+		<meta name="theme-color" content="#9ecae1" />
 
 		<meta name="author" content="Kristofer Rye" />
 

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -14,7 +14,7 @@
 
 		<meta name="viewport" content="width=device-width, initial-scale=1">
 		<meta name="version" content="<%= @git_describe %>" />
-		<meta name="theme-color" content="#9ecae1" />
+		<meta name="theme-color" content="#08519c" />
 
 		<meta name="author" content="Kristofer Rye" />
 


### PR DESCRIPTION
This PR resolves #36 by adding a `theme-color` meta to the `index.html` view which provides a nice pretty color for Android Chrome users.  This is a basically non-functional change, so I am not worried about it breaking anything.
