### PR TITLE
Delete resume-animations.scss and References To It

### DIFF
--- a/views/resume.html.erb
+++ b/views/resume.html.erb
@@ -10,7 +10,6 @@
 		<link rel="stylesheet" href="css/resume-body.css" />
 		<link rel="stylesheet" href="css/resume-header.css" />
 		<link rel="stylesheet" href="css/resume-print.css" />
-		<link rel="stylesheet" href="css/resume-animations.css" />
 
 		<!-- Load the CMU Serif font -->
 		<link rel="stylesheet" href="fonts/Computer Modern/Serif/cmun-serif.css" />


### PR DESCRIPTION
This PR resolves #41 by deleting `views/css/resume-animations.scss` and references to it by `views/resume.html.erb`.  This was an unused SCSS file that was taking up cycles.
