### PR TITLE
Dynamic Trianglify Code

### DIFF
--- a/lib/site/cache.rb
+++ b/lib/site/cache.rb
@@ -165,7 +165,13 @@ module Site
 										"#{readable_file} is a recognized view format; rendering"
 									end
 
-									contents = Tilt.new(file, default_encoding: 'UTF-8').render
+									begin
+										contents = Tilt.new(file, default_encoding: 'UTF-8').render
+									rescue => error
+										Site::Logger.error("Worker [#{worker_number}] (Tilt)") do
+											"#{error.class}: #{error.message}\n\t" + error.backtrace.join("\n\t")
+										end
+									end
 								else
 									Site::Logger.debug("Worker [#{worker_number}]") do
 										"#{readable_file} is not a recognized view; storing statically"
@@ -179,13 +185,13 @@ module Site
 								encoded = Digest::SHA1.base64digest(contents)
 
 								file_type, parent = case readable_file
-																		when /^static/
-																			[:static, @static_directory]
-																		when /^views/
-																			[:view, @views_directory]
-																		else
-																			[nil, @root_directory]
-																		end
+								                    when /^static/
+									                    [:static, @static_directory]
+								                    when /^views/
+									                    [:view, @views_directory]
+								                    else
+									                    [nil, @root_directory]
+								                    end
 
 								relative_path = Pathname.new(file).relative_path_from(Pathname.new(parent))
 
@@ -199,34 +205,39 @@ module Site
 									end
 
 									routes = case file_type
-													 when :static
-														 [File.join('', relative_path)]
-													 when :view
-														 case primary_mime_type
-														 when 'application/x-sass', 'application/x-scss'
-															 [File.join('', File.join(File.dirname(relative_path), File.basename(relative_path, File.extname(relative_path)) + '.css'))]
-														 when 'application/x-coffee'
-															 [File.join('', File.join(File.dirname(relative_path), File.basename(relative_path, File.extname(relative_path)) + '.js'))]
-														 when 'application/x-eruby'
-															 filename = File.basename(relative_path, File.extname(relative_path))
-															 dirname = File.dirname(relative_path)
-															 base = Pathname.new(File.join(dirname, filename)).relative_path_from(Pathname.new(dirname))
+									         when :static
+										         [File.join('', relative_path)]
+									         when :view
+										         case primary_mime_type
+										         when 'application/x-sass', 'application/x-scss'
+											         [File.join('', File.join(File.dirname(relative_path), File.basename(relative_path, File.extname(relative_path)) + '.css'))]
+										         when 'application/x-coffee'
+											         [File.join('', File.join(File.dirname(relative_path), File.basename(relative_path, File.extname(relative_path)) + '.js'))]
+										         when 'application/x-eruby'
+											         filename = File.basename(relative_path, File.extname(relative_path))
+											         dirname = File.dirname(relative_path)
+											         base = Pathname.new(File.join(dirname, filename)).relative_path_from(Pathname.new(dirname))
 
-															 ary = [File.join('', base)]
-															 ary
-														 end
-													 else
+											         ary = [File.join('', base)]
+											         ary
+										         end
+									         else
+									         end
 
-													 end
+									if !routes
+										Site::Logger.warn("Worker [#{worker_number}]") do
+											"#{readable_file} did not generate any routes!"
+										end
+									else
+										completed_routes = routes.map do |_route|
+											@application.get(_route) {
+												entry = self.class.class_variable_get(:@@cache).entries[file]
 
-									routes = routes.map do |_route|
-										@application.get(_route) {
-											entry = self.class.class_variable_get(:@@cache).entries[file]
+												content_type MIME::Types.type_for(_route).first.to_s
 
-											content_type MIME::Types.type_for(_route).first.to_s
-
-											entry[:contents]
-										}
+												entry[:contents]
+											}
+										end
 									end
 
 									@entries[file] = {

--- a/views/css/index.scss
+++ b/views/css/index.scss
@@ -56,7 +56,7 @@
 	}
 }
 
-.trianglify-me {
+.trianglify-target {
 	background-size: cover;
 	background-repeat: no-repeat;
 }

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -27,7 +27,7 @@
 	</head>
 
 	<body class="index computer-modern">
-		<div class="hero center-contents trianglify-me">
+		<div class="hero center-contents trianglify-target">
 			<div class="container">
 				<div class="name hero-space-top-padding">
 					<span class="first full">kris<span class="aux">tofer</span></span>&nbsp;<span class="last">rye</span>

--- a/views/index.html.erb
+++ b/views/index.html.erb
@@ -27,7 +27,7 @@
 	</head>
 
 	<body class="index computer-modern">
-		<div class="hero center-contents trianglify-target">
+		<div class="hero center-contents trianglify-target" data-width="2048" data-height="2048" data-cell_size="128" data-x_colors="Blues">
 			<div class="container">
 				<div class="name hero-space-top-padding">
 					<span class="first full">kris<span class="aux">tofer</span></span>&nbsp;<span class="last">rye</span>
@@ -52,28 +52,31 @@
 
 		<script src="js/global.js"></script>
 		<script src="https://cdnjs.cloudflare.com/ajax/libs/trianglify/1.0.1/trianglify.min.js"></script>
-		<script>
-		/* Generate a 2048x2048 Blues triangle pattern */
-		var trianglifyParameter = {
-			width: 2048,
-			height: 2048,
-			cell_size: 128,
-			x_colors: 'Blues'
-		};
 
-		window.__Trianglifier__ = Trianglify(trianglifyParameter);
+		<script src="js/trianglify.js"></script>
 
-		/* Grab the SVG element so we can tweak it */
-		var svg = window.__Trianglifier__.svg();
+		<!-- <script>
+				 /* Generate a 2048x2048 Blues triangle pattern */
+				 var trianglifyParameter = {
+				 width: 2048,
+				 height: 2048,
+				 cell_size: 128,
+				 x_colors: 'Blues'
+				 };
 
-		/* Make the SVG element standards-conformant so that people won't whine */
-		svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+				 window.__Trianglifier__ = Trianglify(trianglifyParameter);
 
-		/* Set the background image of all .trianglify-me elements */
-		[].slice.call(document.querySelectorAll('.trianglify-me')).forEach(function (e) {
-			e.style.backgroundImage = "linear-gradient(rgba(0,0,0,0.75),rgba(0,0,0,0.6)),url('data:image/svg+xml;base64," + window.btoa(svg.outerHTML) + "')";
-		});
-		</script>
+				 /* Grab the SVG element so we can tweak it */
+				 var svg = window.__Trianglifier__.svg();
+
+				 /* Make the SVG element standards-conformant so that people won't whine */
+				 svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+
+				 /* Set the background image of all .trianglify-me elements */
+				 [].slice.call(document.querySelectorAll('.trianglify-target')).forEach(function (e) {
+				 e.style.backgroundImage = "linear-gradient(rgba(0,0,0,0.75),rgba(0,0,0,0.6)),url('data:image/svg+xml;base64," + window.btoa(svg.outerHTML) + "')";
+				 });
+				 </script> -->
 		<script src="js/index.js"></script>
 
 		<script>(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');ga('create', 'UA-77379897-1','auto');ga('set','appVersion','<%= @git_describe %>');ga('send','pageview');</script>

--- a/views/js/trianglify.coffee
+++ b/views/js/trianglify.coffee
@@ -1,0 +1,31 @@
+trianglifyTargets = document.querySelectorAll('.trianglify-target')
+
+trianglifyTargets.forEach (element) ->
+	parameter = {}
+
+	parameter.width = parseInt(element.dataset.width) if element.dataset.width
+	parameter.height = parseInt(element.dataset.height) if element.dataset.height
+
+	parameter.cell_size = parseInt(element.dataset.cell_size) if element.dataset.cell_size
+	parameter.variance = parseFloat(element.dataset.variance) if element.dataset.variance
+	parameter.seed = seed if element.dataset.seed
+
+	parameter.x_colors = element.dataset.x_colors	if element.dataset.x_colors
+	parameter.y_colors = element.dataset.y_colors if element.dataset.y_colors
+	parameter.color_space = element.dataset.color_space if element.dataset.color_space
+	parameter.color_function = element.dataset.color_function if element.dataset.color_function
+	parameter.stroke_width = parseFloat(element.dataset.stroke_width) if element.dataset.stroke_width
+
+	__trianglifier__ = Trianglify(parameter)
+
+	svg = __trianglifier__.svg()
+	svg.setAttribute('xmlns', 'http://www.w3.org/2000/svg')
+
+	first_stop = 'rgba(0, 0, 0, 0.75)'
+	last_stop = 'rgba(0, 0, 0, 0.6)'
+
+	linear_gradient = "linear-gradient(#{first_stop}, #{last_stop})"
+
+	svg_data_url = "url('data:image/svg+xml;base64,#{window.btoa(svg.outerHTML)}')";
+
+	element.style.backgroundImage = "#{linear_gradient}, #{svg_data_url}"


### PR DESCRIPTION
This PR resolves #46 by introducing more dynamic Trianglify generation code.  Check out the example code used in #46, and also check out the `views/index.html.erb` file for an example of this in practice.  The major win here is that Trianglify can be used in multiple different places, so this will work for situations where a page needs more than one Trianglify drawing to be drawn.
