### PR TITLE
gitignore: Ignore patch files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 
 # Ignore documentation
 /docs/*
+
+# Ignore .patch files
+*.patch


### PR DESCRIPTION
.patch files are handy to have downloaded to a project folder, but it is necessary to ignore these so as to prevent bloating.
