### PR TITLE
MultiDelegator.delegate: Do not use prefix _ for a variable not used

### DIFF
--- a/lib/site/multi_delegator.rb
+++ b/lib/site/multi_delegator.rb
@@ -10,10 +10,10 @@ module Site
 		end
 
 		def self.delegate(*methods)
-			methods.each do |_method|
-				define_method(_method) do |*arguments|
-					@targets.map do |_target|
-						_target.send(_method, *arguments)
+			methods.each do |method|
+				define_method(method) do |*arguments|
+					@targets.map do |target|
+						target.send(_method, *arguments)
 					end
 				end
 			end


### PR DESCRIPTION
This PR resolves #76 and #77 by changing the variable names in question.
