### PR TITLE
docker-compose: Restart on Fail

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
 
   web-production-9300:
     image: kryestofer/krye.io:latest
+    restart: unless-stopped
     ports:
       - '9300:80'
     environment:
@@ -20,6 +21,7 @@ services:
 
   web-production-9301:
     image: kryestofer/krye.io:latest
+    restart: unless-stopped
     ports:
       - '9301:80'
     environment:
@@ -30,6 +32,7 @@ services:
 
   web-staging-9200:
     image: kryestofer/krye.io:HEAD
+    restart: unless-stopped
     ports:
       - '9200:80'
     environment:

--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -1,5 +1,7 @@
 require 'redis'
 
+require 'site/logger'
+
 module Site
 
 	class RedisAdapter < Adapter
@@ -29,6 +31,16 @@ module Site
 			end
 
 			@redis = Redis.new redis_opts
+
+			begin
+				result = @redis.ping
+				Logger.info "Redis responded to PING, ready to roll..."
+			rescue Exception => e
+				Logger.dump_exception e
+				Logger.warn "Closing on exception in DB connection."
+
+				exit 1
+			end
 		end
 
 		def store(key, object)

--- a/lib/site/logger.rb
+++ b/lib/site/logger.rb
@@ -11,4 +11,24 @@ module Site
 	Logger = Logger.new MultiDelegator.delegate(:write, :close).to(STDOUT, LOG_FILE)
 	self::Logger.level = ::Logger::INFO
 
+	def Logger.dump_exception(exception)
+		begin
+			filename, line, rest = caller[0].split(':')
+
+			file_pathname = Pathname.new(filename)
+			basename = file_pathname.relative_path_from(Pathname.new(Site::ROOT_DIRECTORY))
+
+			program_name = "#{basename}:#{line}"
+			prefix = "#{rest}: "
+
+			error(program_name) { "#{prefix}#{exception.message}" }
+
+			exception.backtrace.each do |line|
+				debug(program_name) { "#{prefix}#{line}" }
+			end
+		rescue Exception => exception
+			abort "got exception in dump_exception: #{exception.message}... agh"
+		end
+	end
+
 end


### PR DESCRIPTION
This adds an exception logging singleton method to `Site::Logger` and causes the Site to abort startup if it can't connect to Redis.  All web images in Compose stack now restart on failure.