### PR TITLE
Update Dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ GEM
     diff-lcs (1.3)
     eventmachine (1.2.2)
     execjs (2.7.0)
-    ffi (1.9.17)
+    ffi (1.9.18)
     formatador (0.2.5)
     github-markup (1.4.1)
     guard (2.14.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GEM
     colorize (0.8.1)
     daemons (1.2.4)
     diff-lcs (1.3)
-    eventmachine (1.2.2)
+    eventmachine (1.2.3)
     execjs (2.7.0)
     ffi (1.9.17)
     formatador (0.2.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,7 @@ GEM
     execjs (2.7.0)
     ffi (1.9.17)
     formatador (0.2.5)
-    github-markup (1.4.1)
+    github-markup (1.4.4)
     guard (2.14.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
     thor (0.19.4)
-    tilt (2.0.6)
+    tilt (2.0.7)
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,4 +106,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   1.14.3
+   1.14.6


### PR DESCRIPTION
This PR involves *only patch bumps* on *only some dependencies.*

As such, it is safe to merge.

Changes are:

* **eventmachine** (1.2.2 ~> 1.2.3) [&delta;: 0, 0, 1]
* **ffi** (1.9.17 ~> 1.9.18) [&delta;: 0, 0, 1]
* **github-markup** (1.4.1 ~> 1.4.4) [&delta;: 0, 0, 3]
* **tilt** (2.0.6 ~> 2.0.7) [&delta;: 0, 0, 1]

Bundler was updated, too.
* **bundler** (1.14.3 ~> 1.14.6) [&delta;: 0, 0, 3]

CI is green locally. Auto-merge (without CI) approved.

*Closes #133.*