### PR TITLE
Cache#get: Improve Exception Handling

### DIFF
--- a/lib/site/cache.rb
+++ b/lib/site/cache.rb
@@ -66,10 +66,10 @@ module Site
 			begin
 				result = @adapter.get(tag)
 
-				raise RuntimeError, "Tag not in Redis" unless result
+				raise "Tag not in Redis" unless result
 
 				result
-			rescue RuntimeError => error
+			rescue Exception => error
 				Logger.dump_exception(error)
 
 				entry = Entry.new(filename)

--- a/lib/site/cache.rb
+++ b/lib/site/cache.rb
@@ -69,7 +69,7 @@ module Site
 				raise "Tag not in Redis" unless result
 
 				result
-			rescue Exception => error
+			rescue StandardError => error
 				Logger.dump_exception(error)
 
 				entry = Entry.new(filename)

--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -38,7 +38,7 @@ module Site
 				Logger.info "redis_adapter" do
 					"Redis PONG-ed, ready to roll..."
 				end
-			rescue Exception => e
+			rescue Redis::BaseConnectionError => e
 				Logger.dump_exception e
 				Logger.warn "redis_adapter" do
 					"Aborting startup due to exception in connection to Redis."

--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -25,7 +25,7 @@ module Site
 
 				printable_opts = replace_values(opts, filtered_opts, "[FILTERED]")
 
-				Logger.info "redis_adapter" do
+				Logger.info "RedisAdapter#initialize" do
 					"Connecting to Redis with opts #{printable_opts}"
 				end
 			end
@@ -35,12 +35,12 @@ module Site
 			begin
 				ping
 
-				Logger.info "redis_adapter" do
+				Logger.info "RedisAdapter#initialize" do
 					"Redis PONG-ed, ready to roll..."
 				end
 			rescue Redis::BaseConnectionError => e
 				Logger.dump_exception e
-				Logger.warn "redis_adapter" do
+				Logger.warn "RedisAdapter#initialize" do
 					"Aborting startup due to exception in connection to Redis."
 				end
 

--- a/lib/site/cache/worker.rb
+++ b/lib/site/cache/worker.rb
@@ -14,6 +14,7 @@ module Site
 		def initialize(pool, id)
 			@pool, @id = pool, id
 			@thread = nil
+
 			Logger.debug("worker-#{id}") do "Initialized!" end
 		end
 


### PR DESCRIPTION
This makes the `get` method quite a bit more successful.  Also, refine the RedisAdapter#initialize method by changing it so that it only catches Redis Connection Errors.

This would be a great place to extend with #148 in the future, so we aren't aborting if Redis isn't present.