### PR TITLE
Server: Move Cache Initialization to After @@routes and @@aliases Are Set

### DIFF
--- a/lib/site/server.rb
+++ b/lib/site/server.rb
@@ -62,10 +62,10 @@ module Site
 			# Do log to the console.
 			set :logging, true
 
-			@@cache = Cache.new(env: ENV, application: self)
-
 			@@routes = {}
 			@@aliases = {}
+
+			@@cache = Cache.new(env: ENV, application: self)
 		end
 
 		def self.set_routes(filename, tag, route, aliases)


### PR DESCRIPTION
This fixes a couple of problems with workers not knowing about these variables, and it also makes some sense.  This also prevents a problem which continually seems to cause these workers to crash if they are spawned early.