### PR TITLE
RedisAdapter: Add with_connection_guard Method And Use It

### DIFF
--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -48,10 +48,11 @@ module Site
 				return block.call(*args)
 			rescue Redis::BaseConnectionError => e
 				Logger.dump_exception e
+
 				if try_count < max_tries
 					Logger.warn "RedisAdapter#with_connection_guard" do "Sleeping 1s and trying again..." end
 
-					sleep 1.0
+					sleep sleep_period
 
 					retry
 				else

--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -32,7 +32,7 @@ module Site
 
 			@redis = Redis.new redis_opts
 
-			with_connection_guard(max_tries: 16) do
+			with_connection_guard(max_tries: 16, exit_status_on_fail: 1) do
 				ping
 
 				Logger.info "RedisAdapter#initialize" do "Redis PONG-ed, ready to roll..." end

--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -39,7 +39,7 @@ module Site
 			end
 		end
 
-		def with_connection_guard(*args, max_tries: 8, interval: 1.0, &block)
+		def with_connection_guard(*args, max_tries: 8, exit_status_on_fail: nil, interval: 1.0, &block)
 			try_count = 0
 
 			begin
@@ -57,7 +57,7 @@ module Site
 				else
 					Logger.fatal "RedisAdapter#with_connection_guard" do "Number of failed tries (#{try_count}) meets or exceeds the maximum number of tries (#{max_tries})... aborting." end
 
-					exit 1
+					exit exit_status_on_fail.to_i if !!exit_status_on_fail
 				end
 			end
 		end

--- a/lib/site/cache/redis_adapter.rb
+++ b/lib/site/cache/redis_adapter.rb
@@ -39,7 +39,7 @@ module Site
 			end
 		end
 
-		def with_connection_guard(*args, max_tries: 8, exit_status_on_fail: nil, interval: 1.0, &block)
+		def with_connection_guard(*args, max_tries: 8, exit_status_on_fail: nil, sleep_period: 1.0, &block)
 			try_count = 0
 
 			begin


### PR DESCRIPTION
This is helpful for other instances where we want to use Guards on behavior. Perhaps this could be generalized to everywhere?

*Closes #148.*