### PR TITLE
Fix new Server response lambdas

### DIFF
--- a/lib/site/server.rb
+++ b/lib/site/server.rb
@@ -102,18 +102,14 @@ module Site
 
 					@@routes.delete(route)
 					@@routes[route] = {tag: tag}
-					@@routes[route][:route] = self.get(route.to_s) do
-						default_route_for(filename, tag, route).call
-					end
+					@@routes[route][:route] = self.get(route.to_s, &Server.default_route_for(filename, tag, route))
 
 					alias_routes_to(aliases, routes)
 				end
 			else
 				# Route to be updated does not already exist.
 				@@routes[route] = {tag: tag}
-				@@routes[route][:route] = self.get(route.to_s) do
-					default_route_for(filename, tag, route).call
-				end
+				@@routes[route][:route] = self.get(route.to_s, &Server.default_route_for(filename, tag, route))
 
 				alias_routes_to(aliases, route)
 			end


### PR DESCRIPTION
I stupidly made this thing not handle requests properly, by passing a sterile lambda call to the `get` handler that didn't have access to the Server helper methods.

This fixes #171 by passing the lambda itself as a Proc to the route handler.  Very efficient, and very customizable.

*Closes #171*.