### PR TITLE
Fix docker-compose problems

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '2'
 services:
   redis:
     image: redis
+    restart: unless-stopped
     expose:
       - '6379'
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     expose:
       - '6379'
     volumes:
-      - './config/redis.conf:/etc/redis.conf'
+      - './config/redis.conf:/etc/redis.conf:Z'
     command: 'redis-server /etc/redis.conf'
 
   web-production-9300:


### PR DESCRIPTION
This PR resolves #181 and #182 by fixing some issues with the Redis configuration—namely, this PR makes us now properly bind-mount `/etc/redis.conf`, and also restart Redis unless manually stopped.