### PR TITLE
Fix a typo in the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ jobs:
             tags: true
 
         - provider: script
-          script: script/docker-deploy $DOCKER_IMAGE:$TRAVIS_COMIT $DOCKER_IMAGE:$TRAVIS_TAG $DOCKER_IMAGE:latest
+          script: script/docker-deploy $DOCKER_IMAGE:$TRAVIS_COMMIT $DOCKER_IMAGE:$TRAVIS_TAG $DOCKER_IMAGE:latest
           on:
             condition: $(script/github-latest-release) == $TRAVIS_TAG
             tags: true


### PR DESCRIPTION
This is a rapid PR that solves a problem with the Travis deployment step for 'latest' releases.