### PR TITLE
Extract default GET route behavior into method

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -134,7 +134,7 @@ DEPENDENCIES
   redis (~> 3.2)
   rspec (~> 3.5)
   rubocop (~> 0.49)
-  sass (~> 3.4)
+  sass (~> 3.5)
   scientist (~> 1.0)
   simplecov (~> 0.13)
   sinatra (~> 1.4)

--- a/lib/site/server.rb
+++ b/lib/site/server.rb
@@ -127,6 +127,20 @@ module Site
 			end
 		end
 
+		def self.default_get_route(filename, tag, path)
+			self.get(path) do
+				lambda do
+					slug = @@cache.get(filename, tag)
+
+					etag slug["digest"]
+
+					content_type MIME::Types.type_for(route.first.to_s)
+
+					Base64.decode64(slug["data"])
+				end.call
+			end
+		end
+
 		def self.deactivate_route(route, aliases)
 			@@routes = {} if !@@routes
 			@@routes[route][:route].deactivate if @@routes[:route].respond_to?(:deactivate)

--- a/lib/site/server.rb
+++ b/lib/site/server.rb
@@ -90,17 +90,7 @@ module Site
 
 					@@routes.delete(route)
 					@@routes[route] = {tag: tag}
-					@@routes[route][:route] = self.get(route.to_s) do
-						lambda do
-							slug = @@cache.get(filename, tag)
-
-							etag slug["digest"]
-
-							content_type MIME::Types.type_for(route).first.to_s
-
-							Base64.decode64(slug["data"])
-						end.call
-					end
+					@@routes[route][:route] = self.default_get_route(filename, tag, route.to_s)
 
 					aliases.each do |alyas|
 						@@aliases[alyas] = route
@@ -109,17 +99,7 @@ module Site
 			else
 				# Route to be updated does not already exist.
 				@@routes[route] = {tag: tag}
-				@@routes[route][:route] = self.get(route.to_s) do
-					lambda do
-						slug = @@cache.get(filename, tag)
-
-						etag slug["digest"]
-
-						content_type MIME::Types.type_for(route).first.to_s
-
-						Base64.decode64(slug["data"])
-					end.call
-				end
+				@@routes[route][:route] = self.default_get_route(filename, tag, route.to_s)
 
 				aliases.each do |alyas|
 					@@aliases[alyas] = route
@@ -134,7 +114,7 @@ module Site
 
 					etag slug["digest"]
 
-					content_type MIME::Types.type_for(route.first.to_s)
+					content_type MIME::Types.type_for(path).first.to_s
 
 					Base64.decode64(slug["data"])
 				end.call


### PR DESCRIPTION
*Closes #169.*

This PR solves #169 by adding a `default_get_route` method to the `Server` to generate the advanced route that is necessary for serving data to clients.  This could be further extracted into a class, Route, that would handle this behavior internally.